### PR TITLE
Update EntityAPIHandler.php

### DIFF
--- a/src/crm/api/handler/EntityAPIHandler.php
+++ b/src/crm/api/handler/EntityAPIHandler.php
@@ -45,7 +45,7 @@ class EntityAPIHandler extends APIHandler
             $responseInstance = APIRequest::getInstance($this)->getAPIResponse();
             $responseJSON = $responseInstance->getResponseJSON();
             $recordDetails = $responseJSON['data'] ?? $responseJSON['users'] ?? [];
-            if (sizeof($recordDetails) == 0) {
+            if (empty($recordDetails)) {
                 throw new ZCRMException("No record data found for the given ID.", APIConstants::RESPONSECODE_NOT_FOUND);
             }
             self::setRecordProperties($recordDetails[0]);

--- a/src/crm/api/handler/EntityAPIHandler.php
+++ b/src/crm/api/handler/EntityAPIHandler.php
@@ -43,7 +43,11 @@ class EntityAPIHandler extends APIHandler
             
             $this->addHeader("Content-Type", "application/json");
             $responseInstance = APIRequest::getInstance($this)->getAPIResponse();
-            $recordDetails = $responseInstance->getResponseJSON()['data'];
+            $responseJSON = $responseInstance->getResponseJSON();
+            $recordDetails = $responseJSON['data'] ?? $responseJSON['users'] ?? [];
+            if (sizeof($recordDetails) == 0) {
+                throw new ZCRMException("No record data found for the given ID.", APIConstants::RESPONSECODE_NOT_FOUND);
+            }
             self::setRecordProperties($recordDetails[0]);
             $responseInstance->setData($this->record);
             return $responseInstance;


### PR DESCRIPTION
Update getRecord method to handle Users records.

This pull request updates the `getRecord` method in `EntityAPIHandler` to handle cases where no record data is found more gracefully. It introduces additional checks for alternative keys in the API response and throws a specific exception when no data is available.

### Improvements to error handling:
* [`src/crm/api/handler/EntityAPIHandler.php`](diffhunk://#diff-9d2be75d53f78f3f3a8211070e010482143a5c17900e451ce5c6bae75a6e4c45L46-R50): Updated the `getRecord` method to check for `data` or `users` keys in the API response and throw a `ZCRMException` with a "No record data found" message if neither is present. This ensures clearer error reporting when no records are available.