### PR TITLE
Refactor ZCRMException class by removing unused properties

### DIFF
--- a/src/crm/exception/ZCRMException.php
+++ b/src/crm/exception/ZCRMException.php
@@ -6,20 +6,8 @@ class ZCRMException extends \Exception
     
     protected $message = 'Unknown exception';
     
-    // Exception message
-    private $string;
-    
     // Unknown
     protected $code = 0;
-    
-    // User-defined exception code
-    protected $file;
-    
-    // Source filename of exception
-    protected $line;
-    
-    // Source line of exception
-    private $trace;
     
     private $exceptionCode = "Unknown";
     


### PR DESCRIPTION
This pull request simplifies the `ZCRMException` class by removing unused properties to streamline the code and reduce redundancy.

Codebase simplification:

* [`src/crm/exception/ZCRMException.php`](diffhunk://#diff-413dae7dac5395c69fb3a8993043882e767ae363e7c184655ebede5822fb2201L9-L23): Removed several unused properties (`$string`, `$file`, `$line`, and `$trace`) from the `ZCRMException` class to make the code cleaner and more maintainable.